### PR TITLE
Add (English) post about our move to Matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public/
 content/.obsidian/
+*~

--- a/content/_index.ko.md
+++ b/content/_index.ko.md
@@ -10,7 +10,7 @@ fn main() {
 ---
 서울의 Rust 이용자 온/오프 모임
 - [한국 러스트 사용자 그룹](https://rust-kr.org/)과 [한국 러스트 사용자 디스코드 그룹 (한국어)](https://discord.gg/rust-kr-487203989830631435)
-- [러스트 서울 밋업(영어)](https://www.meetup.com/rust-seoul-meetup/), [러스트 서울 텔레그램 그룹(영어)](https://t.me/joinchat/CACX3RXCO8J4EGbQD5B-tw), [러스트 서울 매트릭스 그룹(영어)](https://matrix.to/#/!eqzKqDmLnxZPrqWQWb:matrix.org?via=guldari.org&via=matrix.org)  
+- [러스트 서울 밋업(영어)](https://www.meetup.com/rust-seoul-meetup/), [러스트 서울 매트릭스 그룹(영어)](https://matrix.to/#/#rust-seoul:matrix.org), [러스트 서울 텔레그램 그룹(영어)](https://t.me/joinchat/CACX3RXCO8J4EGbQD5B-tw)
 
 ---
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -9,10 +9,9 @@ fn main() {
 ---
 Seoul Rust users on/off gatherings
 - [Korean Rust User Group](https://rust-kr.org/) and [Korean Rust Users Discord Group (Korean)](https://discord.gg/rust-kr-487203989830631435)
-- [Rust Meetup (English)](https://www.meetup.com/rust-seoul-meetup/) and  
-  [Rust Seoul Telegram chat room (English)](https://t.me/joinchat/CACX3RXCO8J4EGbQD5B-tw),  
-  [Rust Seoul Matrix group (English)](https://matrix.to/#/!eqzKqDmLnxZPrqWQWb:matrix.org?via=guldari.org&via=matrix.org)
-
+- [Rust Meetup (English)](https://www.meetup.com/rust-seoul-meetup/),
+  [Rust Seoul Matrix group (English)](https://matrix.to/#/#rust-seoul:matrix.org), and
+  [Rust Seoul Telegram chat room (English)](https://t.me/joinchat/CACX3RXCO8J4EGbQD5B-tw)
 ---
 
 seoul.rs is written with the Zola static site generator and hosted on GitHub Pages.

--- a/content/news/find-us-on-matrix.md
+++ b/content/news/find-us-on-matrix.md
@@ -1,0 +1,61 @@
++++
+title = "Find us on Matrix"
+date = "2026-04-12"
+[taxonomies]
+authors = ["Ian Wagner"]
+tags = ["meta"]
++++
+
+As the Seoul Rust meetup, we try to provide an inclusive space for Rustaceans to gather.
+Our regular meetups are one part of that mission, but we also provide an online chat space
+to discuss Rust, among other things.
+
+Over the last few months, we received several reports of new members being unable to join the conversation on Telegram.
+Telegram recently started requiring most new members in many countries, including South Korea,
+to pay for a Telegram Premium subscription in order to activate an account.
+Since Telegram is not widely used in South Korea, this has been a huge barrier to building a welcoming community.
+
+With this in mind, we have decided to create a room on Matrix, a decentralized chat system.
+It is federated, much like Mastodon, giving users the ability to choose whichever server they like.
+Though we recommend most new users simply try out the public matrix.org server,
+which is run by the Matrix Foundation.
+
+# How to get started
+
+## 1. Get a Matrix client
+
+There are [dozens of apps](https://matrix.org/ecosystem/clients/) which let you chat on Matrix.
+It's a bit overwhelming, so here are the ones we recommend to get started.
+(You can always try another app later.)
+
+### Element X (iOS and Android)
+
+[Element X](https://matrix.org/ecosystem/clients/element-x/) provides a well-polished user experience and is our first recommendation for mobile users.
+If you look around at client comparisons, you'll often see claims that Element X does not support some features.
+The most commonly referenced one is "spaces" (a way of grouping "rooms", much like a Discord server).
+This is no longer correct, so don't hesitate to try Element X.
+
+### Element Desktop (Linux, macOS, Windows, and Web)
+
+Also from Element, [Element Desktop](https://matrix.org/ecosystem/clients/element/) has a similar UX to Element X and other chat apps.
+This also works on the web, so you can try it out without installing anything.
+
+## 2. Create an account
+
+During the app setup, you will be prompted to set up an account.
+Choose the matrix.org homeserver and follow the steps.
+
+## 3. Join the room
+
+You should be able to join the room by clicking [this link](https://matrix.to/#/#rust-seoul:matrix.org).
+You can also manually join `#rust-seoul:matrix.org`.
+
+# What's happening to the Telegram channel?
+
+We consider Matrix to be our primary live chat platform going forward.
+However, we'll keep our Telegram channel active indefinitely.
+
+We have set up a bridge, which ensures that messages are synced between both platforms.
+Note that some features do not work across the bridge.
+For example, at the time of this writing, reactions to don carry over.
+But basic messaging, replies, and images are all synced.


### PR DESCRIPTION
Adds an English post regrading our move to Matrix, and adjusts the orer of our chat platforms on the home page.

I think your Korean will be better understood than mine @seungjin, so I'll leave translating to you.